### PR TITLE
PYTHON-4078: Remove `cron: @weekly` from .evergreen

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -67,7 +67,6 @@ tasks:
 buildvariants:
   - name: test-semantic-kernel-python-ubuntu
     display_name: Semantic-Kernel Ubuntu Python
-    cron: @weekly
     expansions:
       DIR: semantic-kernel-python
       REPO_NAME: semantic-kernel
@@ -79,7 +78,6 @@ buildvariants:
 
   - name: test-langchain-python-ubuntu
     display_name: Langchain Ubuntu Python
-    cron: @weekly
     expansions:
       DIR: langchain-python
       REPO_NAME: langchain


### PR DESCRIPTION
The intended usage in to use [`Periodic Builds`](https://docs.devprod.prod.corp.mongodb.com/evergreen/Project-Configuration/Project-and-Distro-Settings#periodic-builds) to run this `.yml` periodically rather than `cron`.

## Test Plan
* https://spruce.mongodb.com/version/657b330ed1fe0704a07412c0/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC