### PR TITLE
chore: upgrade atlas to 1.16

### DIFF
--- a/.evergreen/provision-atlas.sh
+++ b/.evergreen/provision-atlas.sh
@@ -13,9 +13,9 @@ DEPLOYMENT_NAME=$DIR
 
 # Download the mongodb tar and extract the binary into the atlas directory
 set -ex
-curl https://fastdl.mongodb.org/mongocli/mongodb-atlas-cli_1.14.0_linux_x86_64.tar.gz -o atlas.tgz
+curl https://fastdl.mongodb.org/mongocli/mongodb-atlas-cli_1.16.0_linux_x86_64.tar.gz -o atlas.tgz
 tar zxf atlas.tgz
-mv mongodb-atlas-cli_1.14.0* atlas
+mv mongodb-atlas-cli_1.16.0* atlas
 
 # Create a local atlas deployment and store the connection string as an env var
 $atlas deployments setup $DIR --type local --force


### PR DESCRIPTION
Upgrading the local atlas installed to 1.16. This should enable support for `vectorSearch` index types. 