### PR TITLE
PYTHON-4287: Update Atlas CLI to 1.18

### DIFF
--- a/.evergreen/provision-atlas.sh
+++ b/.evergreen/provision-atlas.sh
@@ -42,6 +42,6 @@ DATABASE=$DATABASE \
     $PYTHON_BINARY $SCAFFOLD_SCRIPT
 
 # If a search index configuration can be found, create the index
-if [ -d "$TARGET_DIR/indexConfig.json" ]; then
+if [ -f "$TARGET_DIR/indexConfig.json" ]; then
     $atlas deployments search indexes create --file $TARGET_DIR/indexConfig.json --deploymentName $DIR
 fi

--- a/.evergreen/provision-atlas.sh
+++ b/.evergreen/provision-atlas.sh
@@ -13,12 +13,12 @@ DEPLOYMENT_NAME=$DIR
 
 # Download the mongodb tar and extract the binary into the atlas directory
 set -ex
-curl https://fastdl.mongodb.org/mongocli/mongodb-atlas-cli_1.16.0_linux_x86_64.tar.gz -o atlas.tgz
+curl https://fastdl.mongodb.org/mongocli/mongodb-atlas-cli_1.18.0_linux_x86_64.tar.gz -o atlas.tgz
 tar zxf atlas.tgz
-mv mongodb-atlas-cli_1.16.0* atlas
+mv mongodb-atlas-cli_1.18.0* atlas
 
 # Create a local atlas deployment and store the connection string as an env var
-$atlas deployments setup $DIR --type local --force
+$atlas deployments setup $DIR --type local --force --debug
 $atlas deployments start $DIR
 CONN_STRING=$($atlas deployments connect $DIR --connectWith connectionString)
 

--- a/.evergreen/provision-atlas.sh
+++ b/.evergreen/provision-atlas.sh
@@ -42,6 +42,6 @@ DATABASE=$DATABASE \
     $PYTHON_BINARY $SCAFFOLD_SCRIPT
 
 # If a search index configuration can be found, create the index
-if [ -f "$TARGET_DIR/indexConfig.json" ]; then
+if [ -d "$TARGET_DIR/indexConfig.json" ]; then
     $atlas deployments search indexes create --file $TARGET_DIR/indexConfig.json --deploymentName $DIR
 fi


### PR DESCRIPTION
Update atlas to 1.18. This is a precursor to supporting the `vectorSearch` type in atlas creation. 