### PR TITLE
[PYTHON-4307] Retries query until response contains number requested

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -142,7 +142,7 @@ buildvariants:
       DIR: chatgpt-retrieval-plugin
       REPO_NAME: chatgpt-retrieval-plugin
       # TODO - Update CLONE_URL: [PYTHON-4291] [PYTHON-4129]
-      CLONE_URL: -b feature/mongodb-datastore --single-branch https://github.com/caseyclements/chatgpt-retrieval-plugin.git
+      CLONE_URL: -b PYTHON-4307-intermittent-failures --single-branch https://github.com/caseyclements/chatgpt-retrieval-plugin.git
       DATABASE: chatgpt_retrieval_plugin_test_db
     run_on:
       - rhel87-small


### PR DESCRIPTION
## Context

We have seen test failures that are suspicious

### chatgpt-retrieval-plugin. 
Results imply that the vector search is returning less than "limit", as defined in Search Vector Index, which is the number of documents requested. I have spoken to Trevor M on #vector-search-engineering who said this should not happen.

I have reproduced this locally two times, both when I ran in PyCharm upon first running after leaving the test for some time, but additional runs wouldn't reproduce. 

### llama-index.
 We get different answers to a query.
I have seen this also happen just once locally, but not reproduce-ably.
Could it be that the vector search is returning different results? I have to dig into the algorithm, but it does have random components.  

I applied the same break clause in llama-index. No changes were required to that repo because a pull-request hasn't been opened yet.


## Changes made

In this branch, I have simply extended the time we wait for our request to return the number of responses asked for.
I've increased the sleep from 2 to 5 seconds, and only break if we get n_results == limit.
