### PR TITLE
[PYTHON-4307] Simple fixes for intermittent failures

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -142,7 +142,7 @@ buildvariants:
       DIR: chatgpt-retrieval-plugin
       REPO_NAME: chatgpt-retrieval-plugin
       # TODO - Update CLONE_URL: [PYTHON-4291] [PYTHON-4129]
-      CLONE_URL: -b feature/mongodb-datastore --single-branch https://github.com/caseyclements/chatgpt-retrieval-plugin.git
+      CLONE_URL: -b PYTHON-4307-intermittent-failures --single-branch https://github.com/caseyclements/chatgpt-retrieval-plugin.git
       DATABASE: chatgpt_retrieval_plugin_test_db
     run_on:
       - rhel87-small


### PR DESCRIPTION
We are seeing intermittent failures in a number of the integrations.

chatgpt-retrieval-plugin returns less results than requested. We address this by  waiting until we get the full response.

llama-index returns a different answer (after response synthesizer called by llama index). We address this by accepting either of the two reponses that we've seen.