### PR TITLE
[PYTHON-4307] Merged fix in chatgpt-retrieval

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -142,7 +142,7 @@ buildvariants:
       DIR: chatgpt-retrieval-plugin
       REPO_NAME: chatgpt-retrieval-plugin
       # TODO - Update CLONE_URL: [PYTHON-4291] [PYTHON-4129]
-      CLONE_URL: -b PYTHON-4307-intermittent-failures --single-branch https://github.com/caseyclements/chatgpt-retrieval-plugin.git
+      CLONE_URL: -b feature/mongodb-datastore --single-branch https://github.com/caseyclements/chatgpt-retrieval-plugin.git
       DATABASE: chatgpt_retrieval_plugin_test_db
     run_on:
       - rhel87-small


### PR DESCRIPTION
Merged test fix into chatgpt-retrieval-plugin's feature/mongodb-datastore branch. 
With that done, this commit poinyts evergreen back to that branch (until upstream maintainers merge.)