### PR TITLE
[Bugfix]: Correct index population on provision-atlas.sh

### DIFF
--- a/.evergreen/provision-atlas.sh
+++ b/.evergreen/provision-atlas.sh
@@ -43,7 +43,7 @@ DATABASE=$DATABASE \
 
 # If a search index configuration can be found, create the index
 if [ -d "$TARGET_DIR/indexes" ]; then
-    for file in "$TARGET_DIR/indexes/*.json"; do
+    for file in $TARGET_DIR/indexes/*.json; do
         $atlas deployments search indexes create --file $file --deploymentName $DIR
     done
 fi


### PR DESCRIPTION
## Summary
Found in **provision-atlas.sh** -- The `for file in $TARGET_DIR/indexes/*.json` loop now removes the quotes as it will expand the glob as one expression "$TARGET_DIR/indexes/*.json" --> "$TARGET_DIR/indexes/x.json, $TARGET_DIR/indexes/y.json" rather than do individual loop iterations. 

## Incorrect Behavior
```bash
for file in "$TARGET_DIR/indexes/*.json"; do
    echo $file "DELIMIT"
done
``` 
outputs, 
```bash
>> echo $TARGET_DIR/indexes/x.json $TARGET_DIR/indexes/y.json DELIMIT
```

## Correct Behavior
```bash
for file in $TARGET_DIR/indexes/*.json; do
    echo $file "DELIMIT"
done
``` 
outputs, 
```bash
>> echo $TARGET_DIR/indexes/x.json DELIMIT
>> echo $TARGET_DIR/indexes/y.json DELIMIT
```


## Test for correctness
Check #7 as it implements the correction. Documenting in its own PR for posterity.