### PR TITLE
[PYTHON-4381] Change docarray branch from caseyclements to docarray/main

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -173,8 +173,7 @@ buildvariants:
     expansions:
       DIR: docarray
       REPO_NAME: docarray
-      # TODO - Update CLONE_URL once pull-request is merged
-      CLONE_URL: -b mongodb-atlas-backend --single-branch https://github.com/caseyclements/docarray.git
+      CLONE_URL: https://github.com/docarray/docarray.git
       DATABASE: docarray_test_db
     run_on:
       - rhel87-small


### PR DESCRIPTION
Now that we have an accepted pull-request onto the upstream main branch, we can update to our tests to run against this branch.