### PR TITLE
[Task] Change semantic-kernel import path

### DIFF
--- a/semantic-kernel-python/run.sh
+++ b/semantic-kernel-python/run.sh
@@ -29,7 +29,7 @@ OPENAI_API_KEY=$openai_api_key \
     AZURE_OPENAI_API_KEY="" \
     MONGODB_ATLAS_CONNECTION_STRING=$CONN_STRING \
     Python_Integration_Tests=1 \
-    uv run pytest tests/integration/connectors/memory/test_mongodb_atlas.py -k test_collection_knn
+    uv run pytest tests/integration/memory/memory_stores/test_mongodb_atlas_memory_store.py -k test_collection_knn
 
 # shellcheck disable=SC2154
 OPENAI_API_KEY=$openai_api_key \
@@ -39,4 +39,4 @@ OPENAI_API_KEY=$openai_api_key \
     AZURE_OPENAI_API_KEY="" \
     MONGODB_ATLAS_CONNECTION_STRING=$CONN_STRING \
     Python_Integration_Tests=1 \
-    uv run pytest tests/integration/connectors/memory/test_mongodb_atlas.py
+    uv run pytest tests/integration/memory/memory_stores/test_mongodb_atlas_memory_store.py


### PR DESCRIPTION
Semantic kernel tests were failing due to the repo changing the location of its test suite. This PR provides the new test suite path.