### PR TITLE
GODRIVER-3464 Update clone URL

### DIFF
--- a/langchaingo-golang/config.env
+++ b/langchaingo-golang/config.env
@@ -1,2 +1,2 @@
 REPO_NAME=langchaingo
-CLONE_URL=" -b GODRIVER-3345 --single-branch https://github.com/prestonvasquez/langchaingo.git"
+CLONE_URL="https://github.com/tmc/langchaingo.git"


### PR DESCRIPTION
GODRIVER-3464

Now that https://github.com/tmc/langchaingo/pull/1025 is merged we can update the clone URL for langchain-go.