### PR TITLE
NODE-6950: add langchainjs to testing pipeline

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -250,6 +250,25 @@ tasks:
       - func: "fetch repo"
       - func: "execute tests"
 
+  - name: test-langchain-js-local
+    tags: [local]
+    commands:
+      - func: "fetch repo"
+      - func: "execute tests"
+      - command: attach.xunit_results
+        params:
+          file: src/langchain-js/langchainjs/libs/langchain-mongodb/results.xml
+
+  - name: test-langchain-js-remote
+    tags: [remote]
+    commands:
+      - func: "fetch repo"
+      - func: "setup remote atlas"
+      - func: "execute tests"
+      - command: attach.xunit_results
+        params:
+          file: src/langchain-js/langchainjs/libs/langchain-mongodb/results.xml
+
 buildvariants:
   - name: test-semantic-kernel-python-rhel
     display_name: Semantic-Kernel RHEL Python
@@ -369,3 +388,13 @@ buildvariants:
       - ubuntu2204-small
     tasks:
       - name: test-langchaingo-local
+
+  - name: test-langchain-js-ubuntu
+    display_name: LangchainJS Ubuntu2204
+    expansions:
+      DIR: langchain-js
+    run_on:
+      - ubuntu2204-small
+    tasks:
+      - name: test-langchain-js-local
+      - name: test-langchain-js-remote

--- a/.evergreen/setup-remote.sh
+++ b/.evergreen/setup-remote.sh
@@ -41,6 +41,9 @@ case $DIR in
     pymongo-voyageai)
         MONGODB_URI=$VOYAGEAI_MONGODB_URI
     ;;
+    langchain-js)
+        MONGODB_URI=$LANGCHAIN_MONGODB_URI
+    ;;
     *)
         echo "Missing config in setup-remote.sh for DIR: $DIR"
         exit 1

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Test execution flow is defined in `.evergreen/config.yml`. The test pipeline's c
 
   - `DIR` -- The subdirectory where the tasks will run
 
-- `run_on` -- Specified platform to run on. `rhel87-small` should be used by default. Any other distro may fail Atlas CLI setup.
+- `run_on` -- Specified platform to run on. `rhel87-small` or `ubuntu2204-small` should be used by default. Any other distro may fail Atlas CLI setup.
 - `tasks` -- Tasks to run. See below for more details
 - `cron` -- The tests are run via a cron job on a nightly cadence. This can be modified by setting a different cadence. Cron jobs can be scheduled using [cron syntax](https://crontab.guru/#0_0_*_*_*)
 

--- a/langchain-js/config.env
+++ b/langchain-js/config.env
@@ -1,3 +1,3 @@
 REPO_NAME=langchainjs
-CLONE_URL="https://github.com/langchain-ai/langchainjs.git"
+REPO_ORG=langchain-ai
 DATABASE=langchain_test_db

--- a/langchain-js/config.env
+++ b/langchain-js/config.env
@@ -1,3 +1,3 @@
 REPO_NAME=langchainjs
-CLONE_URL="https://github.com/baileympearson/langchainjs.git"
+CLONE_URL="https://github.com/langchain-ai/langchainjs.git"
 DATABASE=langchain_test_db

--- a/langchain-js/config.env
+++ b/langchain-js/config.env
@@ -1,0 +1,3 @@
+REPO_NAME=langchainjs
+CLONE_URL="https://github.com/baileympearson/langchainjs.git"
+DATABASE=langchain_test_db

--- a/langchain-js/indexes/langchain_test.json
+++ b/langchain-js/indexes/langchain_test.json
@@ -1,0 +1,18 @@
+{
+    "name": "default",
+    "type": "search",
+    "mappings": {
+        "fields": {
+            "e": {
+                "type": "number"
+            },
+            "embedding": {
+                "dimensions": 1536,
+                "similarity": "euclidean",
+                "type": "knnVector"
+            }
+        }
+    },
+    "database": "langchain",
+    "collectionName": "test"
+}

--- a/langchain-js/run.sh
+++ b/langchain-js/run.sh
@@ -2,11 +2,6 @@
 
 set -o errexit
 
-# TODO: remove before merging
-git branch
-git switch use-local-atlas
-git log -n 1
-
 setup_remote_atlas() {
     # Get the MONGODB_URI and OPENAI_API_KEY.
     SCRIPT_DIR=$(realpath "$(dirname ${BASH_SOURCE[0]})")

--- a/langchain-js/run.sh
+++ b/langchain-js/run.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-
 set -o errexit
 
 setup_remote_atlas() {
@@ -12,14 +11,12 @@ setup_remote_atlas() {
         source $ROOT_DIR/env.sh
     fi
 
-    bash ../../.evergreen/fetch-secrets.sh
+    bash "$ROOT_DIR/.evergreen/fetch-secrets.sh"
     source secrets-export.sh
 
     if [[ -n "$MONGODB_URI" ]]; then
         export MONGODB_ATLAS_URI=$MONGODB_URI
     fi
-
-    echo "MONGODB_ATLAS_URI: $MONGODB_ATLAS_URI"
 }
 
 setup_node_and_yarn() {

--- a/langchain-js/run.sh
+++ b/langchain-js/run.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+set -o errexit
+
+# TODO: remove before merging
+git branch
+git switch use-local-atlas
+git log -n 1
+
+setup_remote_atlas() {
+    # Get the MONGODB_URI and OPENAI_API_KEY.
+    SCRIPT_DIR=$(realpath "$(dirname ${BASH_SOURCE[0]})")
+    ROOT_DIR=$(dirname $SCRIPT_DIR)
+
+    if [[ -f "$ROOT_DIR/env.sh" ]]; then
+        echo "Sourcing $ROOT_DIR/env.sh"
+        source $ROOT_DIR/env.sh
+    fi
+
+    bash ../../.evergreen/fetch-secrets.sh
+    source secrets-export.sh
+
+    if [[ -n "$MONGODB_URI" ]]; then
+        export MONGODB_ATLAS_URI=$MONGODB_URI
+    fi
+
+    echo "MONGODB_ATLAS_URI: $MONGODB_ATLAS_URI"
+}
+
+setup_node_and_yarn() {
+    # setup node, npm and yarn
+    PATH=/opt/devtools/node22/bin:$(pwd)/bin:$PATH
+    npm_config_prefix=$(pwd)
+    export PATH
+    export npm_config_prefix
+
+    npm install --global yarn
+}
+
+setup_langchain_integration() {
+    cd libs/langchain-mongodb
+
+    yarn install
+    yarn build
+
+    yarn add --dev jest-junit
+    export JEST_JUNIT_OUTPUT_NAME=results.xml
+
+    # optionally enable to debug local atlas in CI.
+    # export DEBUG=testcontainers*
+}
+
+setup_remote_atlas
+setup_node_and_yarn
+setup_langchain_integration
+
+yarn test:int --reporters=default --reporters=jest-junit


### PR DESCRIPTION
This PR adds testing of langchainjs' mongodb integration in the testing pipeline.  This PR currently uses a branch from my fork of langchainjs.  If this PR is ready to merge before https://github.com/langchain-ai/langchainjs/pull/8154, I'll file a ticket to remove the reference to my langchainjs fork after https://github.com/langchain-ai/langchainjs/pull/8154 merges and we can merge this PR.