### PR TITLE
INTPYTHON-663 Skip non-tokenized filter test in langchaingo

### DIFF
--- a/langchaingo-golang/run.sh
+++ b/langchaingo-golang/run.sh
@@ -10,6 +10,6 @@ export PATH="$PATH:/opt/golang/$GO_VERSION/bin"
 export GOROOT="/opt/golang/$GO_VERSION"
 
 # TODO(GODRIVER-3606): Update expected error in LangChainGo test for
-# non-tokenized filter
+# non-tokenized filter.
 go test -v -failfast -race -shuffle=on \
   -skip "TestStore_SimilaritySearch_NonExactQuery/with_non-tokenized_filter"

--- a/langchaingo-golang/run.sh
+++ b/langchaingo-golang/run.sh
@@ -9,4 +9,7 @@ cd vectorstores/mongovector
 export PATH="$PATH:/opt/golang/$GO_VERSION/bin"
 export GOROOT="/opt/golang/$GO_VERSION"
 
-go test -v -failfast -race -shuffle=on
+# TODO(GODRIVER-3606): Update regression with expected test error in
+# LangChainGo for non-tokenized filter.
+go test -v -failfast -race -shuffle=on \
+  -skip "TestStore_SimilaritySearch_NonExactQuery/with_non-tokenized_filter"

--- a/langchaingo-golang/run.sh
+++ b/langchaingo-golang/run.sh
@@ -9,7 +9,7 @@ cd vectorstores/mongovector
 export PATH="$PATH:/opt/golang/$GO_VERSION/bin"
 export GOROOT="/opt/golang/$GO_VERSION"
 
-# TODO(GODRIVER-3606): Update regression with expected test error in
-# LangChainGo for non-tokenized filter.
+# TODO(GODRIVER-3606): Update expected error in LangChainGo test for
+# non-tokenized filter
 go test -v -failfast -race -shuffle=on \
   -skip "TestStore_SimilaritySearch_NonExactQuery/with_non-tokenized_filter"


### PR DESCRIPTION
There appears to be a regression in the expected error for non-tokenized filter and the test should now expect the following error:

> 'pageContent' needs to be indexed as filter

Suggest skipping the failing test for now, deferring the LCG update to GODRIVER-3606.