### PR TITLE
Update the .NET SDK to 9.0.

### DIFF
--- a/semantic-kernel-csharp/run.sh
+++ b/semantic-kernel-csharp/run.sh
@@ -11,7 +11,7 @@ mkdir -p "$DOTNET_SDK_PATH"
 echo "Downloading .NET SDK installer into $DOTNET_SDK_PATH folder..."
 curl -Lfo "$DOTNET_SDK_PATH"/dotnet-install.sh https://dot.net/v1/dotnet-install.sh
 echo "Installing .NET LTS SDK..."
-bash "$DOTNET_SDK_PATH"/dotnet-install.sh --channel 8.0 --install-dir "$DOTNET_SDK_PATH" --no-path
+bash "$DOTNET_SDK_PATH"/dotnet-install.sh --channel 9.0 --install-dir "$DOTNET_SDK_PATH" --no-path
 
 # The tests use the TestContainers.Net library which requires docker.
 # RHEL 8 and 9 don't support docker so we have the setup below to emulate docker with podman


### PR DESCRIPTION
Possibly will resolve the unexpected build failure on the Semantic Kernel C# solution since the tooling was bumped upstream from 4.12 to 4.14 in https://github.com/microsoft/semantic-kernel/commit/26ca94454ba32d12b419e5b1151fa3f019f7cc1d