### PR TITLE
CSHARP-5686: Fix .NET build issues and disable most SK.NET tests

### DIFF
--- a/semantic-kernel-csharp/run.sh
+++ b/semantic-kernel-csharp/run.sh
@@ -11,7 +11,7 @@ mkdir -p "$DOTNET_SDK_PATH"
 echo "Downloading .NET SDK installer into $DOTNET_SDK_PATH folder..."
 curl -Lfo "$DOTNET_SDK_PATH"/dotnet-install.sh https://dot.net/v1/dotnet-install.sh
 echo "Installing .NET LTS SDK..."
-bash "$DOTNET_SDK_PATH"/dotnet-install.sh --channel 8.0 --install-dir "$DOTNET_SDK_PATH" --no-path
+bash "$DOTNET_SDK_PATH"/dotnet-install.sh --channel 9.0 --install-dir "$DOTNET_SDK_PATH" --no-path
 
 # The tests use the TestContainers.Net library which requires docker.
 # RHEL 8 and 9 don't support docker so we have the setup below to emulate docker with podman

--- a/semantic-kernel-csharp/run.sh
+++ b/semantic-kernel-csharp/run.sh
@@ -31,5 +31,5 @@ sed -i -e 's/"The MongoDB container is intermittently timing out at startup time
 # Remove the attribute blocking tests so we can run them
 sed -i -e 's/\[DisableVectorStoreTests(Skip = "The MongoDB container is intermittently timing out at startup time blocking prs, so these test should be run manually.")\]//g' dotnet/src/IntegrationTests/Connectors/Memory/MongoDB/MongoDBVectorStoreTests.cs
 
-echo "Running MongoDBVectorStoreTests and MongoDBVectorStoreRecordCollectionTests"
-sudo $DOTNET_SDK_PATH/dotnet test dotnet/src/IntegrationTests/IntegrationTests.csproj --filter "SemanticKernel.IntegrationTests.Connectors.MongoDB.MongoDBVectorStoreTests | SemanticKernel.IntegrationTests.Connectors.MongoDB.MongoDBVectorStoreRecordCollectionTests"
+echo "Running MongoDBVectorStoreTests"
+sudo $DOTNET_SDK_PATH/dotnet test dotnet/src/IntegrationTests/IntegrationTests.csproj --filter "SemanticKernel.IntegrationTests.Connectors.MongoDB.MongoDBVectorStoreTests"

--- a/semantic-kernel-csharp/run.sh
+++ b/semantic-kernel-csharp/run.sh
@@ -10,8 +10,10 @@ mkdir -p "$DOTNET_SDK_PATH"
 
 echo "Downloading .NET SDK installer into $DOTNET_SDK_PATH folder..."
 curl -Lfo "$DOTNET_SDK_PATH"/dotnet-install.sh https://dot.net/v1/dotnet-install.sh
-echo "Installing .NET LTS SDK..."
+echo "Installing .NET 9.0 SDK..."
 bash "$DOTNET_SDK_PATH"/dotnet-install.sh --channel 9.0 --install-dir "$DOTNET_SDK_PATH" --no-path
+echo "Installing .NET 8.0 runtime..."
+bash "$DOTNET_SDK_PATH"/dotnet-install.sh --channel 8.0 --install-dir "$DOTNET_SDK_PATH" --no-path --runtime dotnet
 
 # The tests use the TestContainers.Net library which requires docker.
 # RHEL 8 and 9 don't support docker so we have the setup below to emulate docker with podman


### PR DESCRIPTION
- Added the .NET 9 SDK to fix the build issues.
- Temporarily disabled most of the tests while we diagnose flakiness.