### PR TITLE
INTPYTHON-715 add langgraph store mongodb to ai ml testing

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -153,6 +153,20 @@ tasks:
       - func: "setup remote atlas"
       - func: "execute tests"
 
+  - name: test-langgraph-store-python-local
+    tags: [local]
+    commands:
+      - func: "fetch repo"
+      - func: "setup local atlas"
+      - func: "execute tests"
+
+  - name: test-langgraph-store-python-remote
+    tags: [remote]
+    commands:
+      - func: "fetch repo"
+      - func: "setup remote atlas"
+      - func: "execute tests"
+
   - name: test-chatgpt-retrieval-plugin-local
     tags: [local]
     commands:
@@ -318,6 +332,17 @@ buildvariants:
     tasks:
       - name: test-langgraph-python-local
       - name: test-langgraph-python-remote
+        batchtime: 10080  # 1 week
+
+  - name: test-langgraph-store-python-rhel
+    display_name: Langgraph Store RHEL Python
+    expansions:
+      DIR: langgraph-store-python
+    run_on:
+      - rhel87-small
+    tasks:
+      - name: test-langgraph-store-python-local
+      - name: test-langgraph-store-python-remote
         batchtime: 10080  # 1 week
 
   # TODO: INTPYTHON-668

--- a/.evergreen/setup-remote.sh
+++ b/.evergreen/setup-remote.sh
@@ -23,7 +23,7 @@ case $DIR in
     semantic-kernel-csharp)
         MONGODB_URI=$SEMANTIC_KERNEL_MONGODB_URI
     ;;
-    langchain-python | langgraph-python)
+    langchain-python | langgraph-python | langgraph-store-python)
         MONGODB_URI=$LANGCHAIN_MONGODB_URI
     ;;
     chatgpt-retrieval-plugin)

--- a/langgraph-store-python/config.env
+++ b/langgraph-store-python/config.env
@@ -1,0 +1,4 @@
+REPO_NAME=langchain-mongodb
+REPO_ORG=langchain-ai
+DATABASE=langgraph-store-test
+REPO_BRANCH=INTPYTHON-661-Async-MongoDBStore

--- a/langgraph-store-python/run.sh
+++ b/langgraph-store-python/run.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# WORKING_DIR = src/langchain-python/langchain
+set -eu
+
+# Get the MONGODB_URI and OPENAI_API_KEY.
+SCRIPT_DIR=$(realpath "$(dirname ${BASH_SOURCE[0]})")
+ROOT_DIR=$(dirname $SCRIPT_DIR)
+. $ROOT_DIR/env.sh
+
+. $ROOT_DIR/.evergreen/utils.sh
+
+PYTHON_BINARY=$(find_python3)
+
+# shellcheck disable=SC2164
+cd libs/langgraph-store-mongodb
+
+$PYTHON_BINARY -m venv venv_pipeline
+source venv_pipeline/bin/activate
+
+pip install uv rust-just
+
+just install
+
+just unit_tests
+
+just integration_tests


### PR DESCRIPTION
[Passing patch](https://spruce.mongodb.com/version/6899d5e4230ab00007119166/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC)

Sets up testing of `langgraph-store-mongodb` package. Previously we were testing langchain-mongodb and langgraph-checkpoint-mongod.

`config.env` currently points to caseyclements:INTPYTHON-661-Simple, so there will be a small change after this one is finisihed.