### PR TITLE
Disable CSharp Remote tests

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -325,17 +325,17 @@ buildvariants:
       # - name: test-semantic-kernel-python-remote
       #   batchtime: 10080  # 1 week
 
-  # - name: test-semantic-kernel-csharp-rhel
-  #   display_name: Semantic-Kernel RHEL CSharp
-  #   tags: [csharp]
-  #   expansions:
-  #     DIR: semantic-kernel-csharp
-  #   run_on:
-  #     - rhel87-small
-  #   tasks:
-  #     - name: test-semantic-kernel-csharp-local
-  #     - name: test-semantic-kernel-csharp-remote
-  #       batchtime: 10080  # 1 week
+  - name: test-semantic-kernel-csharp-rhel
+    display_name: Semantic-Kernel RHEL CSharp
+    tags: [csharp]
+    expansions:
+      DIR: semantic-kernel-csharp
+    run_on:
+      - rhel87-small
+    tasks:
+      - name: test-semantic-kernel-csharp-local
+      # - name: test-semantic-kernel-csharp-remote
+      #   batchtime: 10080  # 1 week
 
   - name: test-langchain-python-rhel
     display_name: Langchain RHEL Python


### PR DESCRIPTION
We need to disable the CSharp remote tests for now.  They are creating a large number of indexes and interfering with other tests, causing multiple test failures across other integrations.

https://jira.mongodb.org/browse/INTPYTHON-740
https://jira.mongodb.org/browse/INTPYTHON-739
https://jira.mongodb.org/browse/INTPYTHON-738