### PR TITLE
INTPYTHON-890 Improve usability of community search

### DIFF
--- a/.evergreen/mongodb-community-search/start-services.sh
+++ b/.evergreen/mongodb-community-search/start-services.sh
@@ -61,6 +61,7 @@ URL="http://127.0.0.1:8080/healthcheck"
 
 MAX_ATTEMPTS=5
 ATTEMPT=1
+set +e
 echo "Waiting for the server to be alive and respond with the expected status..."
 while [ "$ATTEMPT" -le "$MAX_ATTEMPTS" ]; do
   echo "Attempt $ATTEMPT of $MAX_ATTEMPTS..."

--- a/.evergreen/mongodb-community-search/start-services.sh
+++ b/.evergreen/mongodb-community-search/start-services.sh
@@ -59,9 +59,12 @@ docker compose up -d
 # Wait for the healthcheck
 URL="http://127.0.0.1:8080/healthcheck"
 
+MAX_ATTEMPTS=5
+ATTEMPT=1
 echo "Waiting for the server to be alive and respond with the expected status..."
-set +e
-while true; do
+while [ "$ATTEMPT" -le "$MAX_ATTEMPTS" ]; do
+  echo "Attempt $ATTEMPT of $MAX_ATTEMPTS..."
+
   # Make the request and capture response with detailed debugging
   RESPONSE=$(curl --max-time 10 -s "$URL")
   CURL_EXIT_CODE=$?
@@ -69,6 +72,7 @@ while true; do
   # Check for Curl exit code
   if [ "$CURL_EXIT_CODE" -ne 0 ]; then
     echo "Curl failed with exit code $CURL_EXIT_CODE, retrying in 2 seconds..."
+    ATTEMPT=$((ATTEMPT + 1))
     sleep 2
     continue
   fi
@@ -80,8 +84,13 @@ while true; do
   fi
 
   echo "Server not ready yet. Retrying in 2 seconds..."
+  ATTEMPT=$((ATTEMPT + 1))
   sleep 2
 done
-set -e
 
 docker compose logs
+
+if [ "$ATTEMPT" -gt "$MAX_ATTEMPTS" ]; then
+  echo "Server did not become ready after $MAX_ATTEMPTS attempts. Failing."
+  exit 1
+fi

--- a/.evergreen/mongodb-community-search/teardown.sh
+++ b/.evergreen/mongodb-community-search/teardown.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -eu
+
+pushd "$(dirname ${BASH_SOURCE:-$0})" > /dev/null
+docker compose down || true
+popd > /dev/null

--- a/.evergreen/utils.sh
+++ b/.evergreen/utils.sh
@@ -63,12 +63,12 @@ setup_local_atlas() {
     popd
     if [ -z "${COMMUNITY_WITH_SEARCH:-}" ]; then
         bash $SCRIPT_DIR/mongodb-community-search/teardown.sh
-        . $SCRIPT_DIR/../drivers-evergreen-tools/.evergreen/run-orchestration.sh --local-atlas -v
+        bash $SCRIPT_DIR/../drivers-evergreen-tools/.evergreen/run-orchestration.sh --local-atlas -v
     else
         if [ -n "${CI:-}" ]; then
             bash $SCRIPT_DIR/../drivers-evergreen-tools/.evergreen/docker/setup.sh
         fi
-        . $SCRIPT_DIR/../drivers-evergreen-tools/.evergreen/stop-orchestration.sh
+        bash $SCRIPT_DIR/../drivers-evergreen-tools/.evergreen/stop-orchestration.sh
         bash $SCRIPT_DIR/mongodb-community-search/start-services.sh
     fi
     export CONN_STRING"=mongodb://127.0.0.1:27017/?directConnection=true"

--- a/.evergreen/utils.sh
+++ b/.evergreen/utils.sh
@@ -62,12 +62,14 @@ setup_local_atlas() {
     git clone https://github.com/mongodb-labs/drivers-evergreen-tools || true
     popd
     if [ -z "${COMMUNITY_WITH_SEARCH:-}" ]; then
+        bash $SCRIPT_DIR/mongodb-community-search/teardown.sh
         . $SCRIPT_DIR/../drivers-evergreen-tools/.evergreen/run-orchestration.sh --local-atlas -v
     else
         if [ -n "${CI:-}" ]; then
             bash $SCRIPT_DIR/../drivers-evergreen-tools/.evergreen/docker/setup.sh
         fi
-        bash .evergreen/mongodb-community-search/start-services.sh
+        . $SCRIPT_DIR/../drivers-evergreen-tools/.evergreen/stop-orchestration.sh
+        bash $SCRIPT_DIR/mongodb-community-search/start-services.sh
     fi
     export CONN_STRING"=mongodb://127.0.0.1:27017/?directConnection=true"
     echo "CONN_STRING=$CONN_STRING" > $SCRIPT_DIR/.local_atlas_uri

--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,7 @@ drivers-evergreen-tools
 atlas
 .evergreen/.local_atlas_uri
 pwfile
+mo-expansion.*
 
 # Secrets
 secrets-export.sh


### PR DESCRIPTION
INTPYTHON-890 

- Use stop-orchestration to shut down any other running servers before starting the community server using docker compose up.
- Run docker compose down to shut down the community server when not running the community server, if docker is available. This should be a teardown.sh script in the community server dir that runs from that directory.
- If we fail to pass the health check, dump the mongot logs using docker compose logs mongot.

Tested locally, switch back and forth between the two types.