### PR TITLE
INTPYTHON-965 Improvements to langchainjs for $rerank

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -309,7 +309,6 @@ tasks:
     tags: [local]
     commands:
       - func: "fetch repo"
-      - func: "setup local atlas"
       - func: "execute tests"
       - command: attach.xunit_results
         params:

--- a/langchain-js/run.sh
+++ b/langchain-js/run.sh
@@ -14,7 +14,7 @@ setup_remote_atlas() {
     bash "$ROOT_DIR/.evergreen/fetch-secrets.sh"
     source secrets-export.sh
 
-    if [[ -n "$MONGODB_URI" ]]; then
+    if [[ "$MONGODB_URI" == mongodb+srv://* ]]; then
         export MONGODB_ATLAS_URI=$MONGODB_URI
     fi
 }

--- a/langchain-js/run.sh
+++ b/langchain-js/run.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -o errexit
 
-setup_remote_atlas() {
-    # Get the MONGODB_URI and OPENAI_API_KEY.
+setup_environment() {
+    # Load secrets and set MONGODB_ATLAS_URI for remote Atlas connections.
     SCRIPT_DIR=$(realpath "$(dirname ${BASH_SOURCE[0]})")
     ROOT_DIR=$(dirname $SCRIPT_DIR)
 
@@ -50,7 +50,7 @@ setup_langchain_integration() {
     # export DEBUG=testcontainers*
 }
 
-setup_remote_atlas
+setup_environment
 setup_node_and_yarn
 setup_langchain_integration
 


### PR DESCRIPTION
## CI/infrastructure fixes (`ai-ml-pipeline-testing` + `langchainjs`)

A series of fixes were required to make the local and remote CI tasks work correctly together.
Failures may continue in `test-langchain-js-local` until the changes are merged from [langchainjs/pull/10944](https://github.com/langchain-ai/langchainjs/pull/10944).

Here are the changes in `ai-ml-pipeline-testing`.  They largely stemmed from an earlier introduction of using testcontainers for local development, the impact being two atlas containers.

**`langchain-js/run.sh`**
- Renamed `setup_remote_atlas` → `setup_environment` to reflect that it only loads secrets and wires up env vars — it does not provision any Atlas container.
- `MONGODB_ATLAS_URI` is now only exported when `MONGODB_URI` is a real Atlas connection (`mongodb+srv://`). Previously it was exported unconditionally, which caused `uri()` to short-circuit to the CI-provided localhost URI and bypass testcontainers entirely.

**`.evergreen/config.yml`**
- Removed `setup local atlas` from `test-langchain-js-local`. That step started `mongodb/mongodb-atlas-local:latest` (no auto-embedding, no Voyage API key) on port 27017, conflicting with testcontainers which also needs port 27017 for the `:preview` image. The JS tests manage their own container lifecycle via testcontainers, consistent with the `test-n8n-js-local` pattern.