### PR TITLE
NODE-7617 Add mastra-js CI integration

### DIFF
--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -330,6 +330,18 @@ tasks:
         params:
           file: src/langchain-js/langchainjs/libs/providers/langchain-mongodb/results.xml
 
+  - name: test-mastra-js-local
+    tags: [local]
+    commands:
+      - func: "fetch repo"
+      - func: "execute tests"
+      - command: attach.xunit_results
+        params:
+          file: src/mastra-js/mastra/stores/mongodb/results-mongodb.xml
+      - command: attach.xunit_results
+        params:
+          file: src/mastra-js/mastra/packages/rag/results-rag.xml
+
   - name: test-mem0-python-local
     tags: [ local ]
     commands:
@@ -549,6 +561,21 @@ buildvariants:
       - ubuntu2204-small
     tasks:
       - name: test-n8n-js-local
+
+  - name: test-mastra-javascript-ubuntu
+    display_name: Mastra Ubuntu2204
+    tags: [javascript]
+    expansions:
+      DIR: mastra-js
+    run_on:
+      - ubuntu2204-small
+    tasks:
+      - name: test-mastra-js-local
+      # TODO: NODE-7617 Add test-mastra-js-remote once stores/mongodb's
+      # vector tests support connecting to a remote Atlas URI (they
+      # currently hardcode mongodb://localhost:27017 / :27018).
+      # - name: test-mastra-js-remote
+      #   batchtime: 10080  # 1 week
 
   - name: test-mem0-python-rhel
     display_name: mem0 RHEL Python

--- a/.evergreen/config.yml
+++ b/.evergreen/config.yml
@@ -571,7 +571,7 @@ buildvariants:
       - ubuntu2204-small
     tasks:
       - name: test-mastra-js-local
-      # TODO: NODE-7617 Add test-mastra-js-remote once stores/mongodb's
+      # TODO: NODE-7719 Add test-mastra-js-remote once stores/mongodb's
       # vector tests support connecting to a remote Atlas URI (they
       # currently hardcode mongodb://localhost:27017 / :27018).
       # - name: test-mastra-js-remote

--- a/mastra-js/config.env
+++ b/mastra-js/config.env
@@ -1,0 +1,2 @@
+REPO_NAME=mastra
+REPO_ORG=mastra-ai

--- a/mastra-js/config.env
+++ b/mastra-js/config.env
@@ -1,2 +1,5 @@
 REPO_NAME=mastra
-REPO_ORG=mastra-ai
+# NODE-7702
+# REPO_ORG=mastra-ai
+REPO_ORG=caseyclements
+REPO_BRANCH=fix-bson-circular-metadata-hang-take2

--- a/mastra-js/run.sh
+++ b/mastra-js/run.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -o errexit
+
+setup_node_and_pnpm() {
+    # setup node, npm and pnpm
+    PATH=/opt/devtools/node22/bin:$(pwd)/bin:$PATH
+    npm_config_prefix=$(pwd)
+    export PATH
+    export npm_config_prefix
+
+    npm install -g pnpm@latest-10
+    npm install --global corepack --force
+    corepack enable
+}
+
+build_mastra_workspace() {
+    pnpm install
+
+    # Building the mongodb store and rag packages also builds their
+    # workspace dependencies (e.g. @mastra/core), per turbo's build
+    # task graph (`dependsOn: ["^build"]` in turbo.json).
+    pnpm turbo --filter "@mastra/mongodb" build
+    pnpm turbo --filter "@mastra/rag" build
+}
+
+run_mongodb_store_tests() {
+    # `pnpm test` here also runs the package's pretest/posttest hooks,
+    # which bring up and tear down the local MongoDB containers this
+    # store's tests connect to (see stores/mongodb/docker-compose.yaml).
+    (
+        cd stores/mongodb
+        pnpm test --reporter=default --reporter=junit --outputFile=./results-mongodb.xml
+    )
+}
+
+run_rag_database_config_tests() {
+    (
+        cd packages/rag
+        pnpm vitest run src/tools/vector-query-database-config.test.ts \
+            --reporter=default --reporter=junit --outputFile=./results-rag.xml
+    )
+}
+
+setup_node_and_pnpm
+build_mastra_workspace
+run_mongodb_store_tests
+run_rag_database_config_tests


### PR DESCRIPTION
## Summary
- Adds a `mastra-js` test directory (`config.env` + `run.sh`) that clones `mastra-ai/mastra` and runs the `@mastra/mongodb` store suite (against local docker-compose MongoDB containers) plus the `@mastra/rag` database-config test.
- Wires these up via a new `test-mastra-js-local` task and `test-mastra-javascript-ubuntu` build variant in `.evergreen/config.yml`.
- No remote variant yet: `stores/mongodb`'s vector tests hardcode `localhost` connection strings, so they can't currently point at a remote Atlas cluster. Left a `# TODO: NODE-7617` marker for this follow-up.

## Test plan
- [x] Verified locally against `/Users/casey.clements/src/mastra`: `pnpm turbo --filter "@mastra/mongodb" build` / `--filter "@mastra/rag" build`, then `pnpm test` in `stores/mongodb` (688 passed, 0 failed, 77 skipped) and the targeted `vector-query-database-config.test.ts` in `packages/rag` (5 passed).
- [x] Ran an uncommitted `evergreen patch` against this branch (`test-mastra-javascript-ubuntu` / `test-mastra-js-local`) to validate on real Evergreen infra.
- [x] Confirm the Evergreen patch build passes end-to-end before marking ready for review.